### PR TITLE
fix: some implementations for compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ In my previous projects, I've grappled with authentication tools like Firebase a
 
 ## How to run
 
+### Clone
+
+Recursive clone is needed to ensure that entire `vendor/postgres` is completely downloaded:
+
+```bash
+git clone --recursive https://github.com/J0sueTM/elauthant.git
+```
+
 ### Configure
 
 ```bash
@@ -32,6 +40,12 @@ PG_USER=my_user PG_PASWORD=123456 ELAUTHENT_VERSION=0.0.01 ./configure
 ```
 
 ### Compile
+
+If you don't have the `libpq` [previously installed](https://www.postgresql.org/docs/current/libpq.html), please compile PostgreSQL with:
+
+```bash
+cd vendor/postgres && make
+```
 
 ```bash
 make all

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ If you don't have the `libpq` [previously installed](https://www.postgresql.org/
 cd vendor/postgres && make
 ```
 
+Then, compile with:
+
 ```bash
 make all
 ```

--- a/configure
+++ b/configure
@@ -57,9 +57,11 @@ PG_DB=${PG_DB:-elauthant_db}
 # submodules
 if [[ -z "$(ls -A ${ELAUTHANT_DIR}/vendor/postgres)" ]]; then
     git submodule update -init --recursive --remote
-    cd vendor/postgres
-    git checkout "tags/REL_${PG_VERSION//./_}"
 fi
+
+cd vendor/postgres
+git checkout "tags/REL_${PG_VERSION//./_}"
+cd ../..
 
 # sql
 cp elauthant.sql "elauthant--${ELAUTHANT_VERSION}.sql"


### PR DESCRIPTION
# Fix for some compiling implementations

1. Add to README about context with `git clone --recursive` (to download PostgreSQL too) and a simple note to compiling it if you don't have `libpq` [previously installed](https://www.postgresql.org/docs/current/libpq.html).
2. Fixing some problem with `.env` generation inside the wrong directory.